### PR TITLE
Fix Web Intents

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -5,6 +5,11 @@ chrome.webRequest.onBeforeRequest.addListener(details => {
 		return;
 	}
 
+	// if the URL is for an intent, don't change the URL
+	if (/twitter.com\/intent\//.test(details.url)) {
+		return;
+	}
+
 	return {
 		redirectUrl: details.url.replace(/^https:\/\/twitter/, 'https://mobile.twitter')
 	};

--- a/extension/background.js
+++ b/extension/background.js
@@ -27,7 +27,7 @@ chrome.webRequest.onBeforeRequest.addListener(details => {
 chrome.webRequest.onBeforeSendHeaders.addListener(details => {
 	// xo wants this to be `const`, but that breaks in Firefox.
 	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1269863
-	for (let header of details.requestHeaders) {
+	for (const header of details.requestHeaders) {
 		if (header.name === 'User-Agent') {
 			if (header.value.includes('Firefox') || header.value.includes('Edge')) {
 				header.value = 'Chrome/50';


### PR DESCRIPTION
This fixes #2. It also fixes an XO error I found:

```
 extension/background.js:30:11
  ⚠  30:11  header is never reassigned, use const instead.  prefer-const
```