### PR TITLE
Fix web intents using the /share URL

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -6,7 +6,7 @@ chrome.webRequest.onBeforeRequest.addListener(details => {
 	}
 
 	// if the URL is for an intent, don't change the URL
-	if (/twitter.com\/intent\//.test(details.url)) {
+	if (/twitter.com\/(intent|share)/.test(details.url)) {
 		return;
 	}
 


### PR DESCRIPTION
This is a fix for #12. We now test if the URL has `/intent` or `/share`. (I think the latter is the old method...)