### PR TITLE
Reduce width and height of the header on profile

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -1,4 +1,5 @@
 #react-root .WBlUyLoP,
-#react-root ._vewY-Vw {
+#react-root ._vewY-Vw,
+#react-root ._1MFKGigQ {
 	max-width: 800px !important;
 }


### PR DESCRIPTION
This fixes #11.

I just applied the same `max-width` that we are using elsewhere for consistency. I didn't think we needed to also reduce the height.