### PR TITLE
Add auto deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - 'node'
+deploy:
+  provider: script
+  script: ./deploy.sh
+  on:
+    branch: master
+    tags: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ev
+zip -r extension.zip extension/
+grunt

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,27 @@
+const zipFileName = 'extension.zip';
+module.exports = function (grunt) {
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+		webstore_upload: { // eslint-disable-line
+			accounts: {
+				default: {
+					cli_auth: true, // eslint-disable-line
+					publish: true,
+					client_id: process.env.CLIENT_ID, // eslint-disable-line
+					client_secret: process.env.CLIENT_SECRET, // eslint-disable-line
+					refresh_token: process.env.REFRESH_TOKEN // eslint-disable-line
+				}
+			},
+			extensions: {
+				refinedTwitter: {
+					appID: 'nlfgmdembofgodcemomfeimamihoknip', // App ID from chrome webstore
+					publish: true,
+					zip: zipFileName
+				}
+			}
+		}
+	});
+
+	grunt.loadNpmTasks('grunt-webstore-upload');
+	grunt.registerTask('default', ['webstore_upload']);
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "test": "xo"
   },
   "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-webstore-upload": "^0.8.10",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
@sindresorhus Same deal as before, and this is pretty much a wholesale copy from Refined GitHub except for the extension's `appID`.

From the last time...

> To get this working we need to set some environment variables for Travis CI. You can do this by adding encrypted credentials to the `.travis.yml` file, or through the Travis CI website. I documented it a bit here https://github.com/paulmolluzzo/test-deploy-chrome

> Once that is done, we actually need to have this in `master` because the bash script is going to check that we're on that branch when it runs the script. You can test this outside of `master` by removing the checks in `./deploy.sh`, but you'll want to put them back in so we aren't deploying non-master branches or PRs, which are likely WIP or something.