### PR TITLE
Revert "Spoof Chrome's User-Agent to fool UA sniffing. (#3)"

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -29,29 +29,3 @@ chrome.webRequest.onBeforeRequest.addListener(details => {
 }, [
 	'blocking'
 ]);
-
-chrome.webRequest.onBeforeSendHeaders.addListener(details => {
-	// xo wants this to be `const`, but that breaks in Firefox.
-	// See https://bugzilla.mozilla.org/show_bug.cgi?id=1269863
-	for (let header of details.requestHeaders) {
-		if (header.name === 'User-Agent') {
-			if (header.value.includes('Firefox') || header.value.includes('Edge')) {
-				header.value = 'Chrome/50';
-			}
-		}
-	}
-
-	return {
-		requestHeaders: details.requestHeaders
-	};
-}, {
-	urls: [
-		'https://mobile.twitter.com/*'
-	],
-	types: [
-		'main_frame'
-	]
-}, [
-	'blocking',
-	'requestHeaders'
-]);

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
       "browser",
       "webextensions"
     ],
-    "rules": {
-      "prefer-const": "off"
-    },
     "ignores": [
       "extension/vendor/**"
     ]


### PR DESCRIPTION
This reverts commit 78bf4e6304fb999db3553daa8f6584ee04ee5953.

[Upstream fixed this][0]. Thanks, @alunny!

[0]: https://github.com/sindresorhus/refined-twitter/pull/3#issuecomment-218616367