### PR TITLE
Added shortcuts for navigating between pictures in a tweet

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -92,6 +92,22 @@ function registerShortcuts(username) {
 	Mousetrap.bind('G', () => {
 		scrollToY(document.body.scrollHeight);
 	});
+
+	Mousetrap.bind('right', () => {
+		const nextBtn = $('button._2p6iBzFu._2UbkmNPH');
+
+		if (nextBtn) {
+			$('button._2p6iBzFu._2UbkmNPH').click();
+		}
+	});
+
+	Mousetrap.bind('left', () => {
+		const prevBtn = $('button._2p6iBzFu.lYVIpMQ4');
+
+		if (prevBtn) {
+			$('button._2p6iBzFu.lYVIpMQ4').click();
+		}
+	});
 	// -- //
 }
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,8 @@ Works on Firefox too, but requires [some manual steps for now](https://github.co
 - Go to Lists: <kbd>g</kbd> <kbd>i</kbd>
 - Go to next tweet: <kbd>j</kbd>
 - Go to previous tweet: <kbd>k</kbd>
+- Go to next photo: <kbd>right</kbd>
+- Go to previous photo: <kbd>left</kbd>
 - Page down: <kbd>Ctrl</kbd> <kbd>d</kbd>
 - Page up: <kbd>Ctrl</kbd> <kbd>u</kbd>
 - Scroll to top: <kbd>g</kbd> <kbd>g</kbd>


### PR DESCRIPTION
I have added keyboard shortcuts for navigating between pictures on a tweet with multiple pictures. Please have a look and merge the changes if you find it alright. It's very minor but I was missing this functionality so added it. Thanks for the extension. :smile: 