### PR TITLE
Replace Emoji in usernames

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -14,6 +14,9 @@ function useNativeEmoji() {
 	$('#stream-items-id .Emoji--forText').replaceWith(function () {
 		return $(this).attr('alt');
 	});
+	$('.Emoji.Emoji--forLinks').replaceWith(function() {
+		return $(this).siblings('span.visuallyhidden').text()
+	})
 }
 
 function hideFollowersActivity() {


### PR DESCRIPTION
I've updated the function that is used for the tweets emoji replacement to also replace them in usernames, either when looking at the stream or when viewing a user profile directly. I'm looking into how to replace them when viewing DMs and I'll update the pull-request later.

@sindresorhus Any reason to restrict emoji replacement with the `#stream-items-id`?