### PR TITLE
Hide `Liked` tweets from stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ We use Twitter a lot and notice many dumb annoyances we'd like to fix. So here b
 - [Removes the annoying suggestions in the search popover](https://user-images.githubusercontent.com/170270/33800304-70198358-dd3d-11e7-9870-477a44f74f4d.png)
 - Fixes the file extension when saving images in tweets. No more `foo.jpg_large`!
 - Uses the original image in tweet image galleries.
+- Hides "Liked" tweets in the stream
 
 Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10).
 

--- a/source/content.js
+++ b/source/content.js
@@ -24,7 +24,7 @@ function hideListAddActivity() {
 }
 
 function hideLikeTweets() {
-	$(".tweet-context .Icon--heartBadge").parents('.js-stream-item').css('display', 'none');
+	$('.tweet-context .Icon--heartBadge').parents('.js-stream-item').css('display', 'none');
 }
 
 async function init() {

--- a/source/content.js
+++ b/source/content.js
@@ -23,6 +23,10 @@ function hideListAddActivity() {
 	$('#stream-items-id .js-activity-list_member_added').css('display', 'none');
 }
 
+function hideLikeTweets() {
+	$(".tweet-context .Icon--heartBadge").parents('.js-stream-item').css('display', 'none');
+}
+
 async function init() {
 	await safeElementReady('body');
 
@@ -54,6 +58,7 @@ function onDomReady() {
 			safely(useNativeEmoji);
 			safely(hideFollowersActivity);
 			safely(hideListAddActivity);
+			safely(hideLikeTweets);
 		});
 	});
 }


### PR DESCRIPTION
Based on @insin's greasemonkey script available here:
https://github.com/insin/greasemonkey/blob/master/twitter-hide-retweetlikes.user.js

Closes #18