### PR TITLE
Drop dom-loaded

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -1,5 +1,4 @@
-import domLoaded from 'dom-loaded';
-import {observeEl, safeElementReady, safely} from './libs/utils';
+import {observeEl, safely} from './libs/utils';
 import autoLoadNewTweets from './features/auto-load-new-tweets';
 import inlineInstagramPhotos from './features/inline-instagram-photos';
 import codeHighlight from './features/code-highlight';
@@ -39,19 +38,6 @@ function hidePromotedTweets() {
 	$('.promoted-tweet').parent().remove();
 }
 
-async function init() {
-	await safeElementReady('body');
-
-	if (document.body.classList.contains('logged-out')) {
-		return;
-	}
-
-	document.documentElement.classList.add('refined-twitter');
-
-	await domLoaded;
-	onDomReady();
-}
-
 function onRouteChange(cb) {
 	observeEl('#doc', cb, {attributes: true});
 }
@@ -71,7 +57,13 @@ function onSingleTweetOpen(cb) {
 	}, {attributes: true});
 }
 
-function onDomReady() {
+function init() {
+	if (document.body.classList.contains('logged-out')) {
+		return;
+	}
+
+	document.documentElement.classList.add('refined-twitter');
+
 	safely(cleanNavbarDropdown);
 
 	onRouteChange(() => {

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -27,7 +27,6 @@
 	},
 	"content_scripts": [
 		{
-			"run_at": "document_start",
 			"matches": [
 				"https://twitter.com/*"
 			],


### PR DESCRIPTION
By default, extensions are run after dom-ready, so no need to be explicit if we don't need to run anything before that event.