### PR TITLE
Allow useNativeEmoji to be undone via Stylish

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -8,17 +8,19 @@ function cleanNavbarDropdown() {
 	$('#user-dropdown').find('[data-nav="all_moments"], [data-nav="ads"], [data-nav="promote-mode"], [data-nav="help_center"]').parent().hide();
 }
 
+const handledClass = `refined-twitter--handled`;
 function useNativeEmoji() {
 	const emojiWrap = emoji => `<span class="Emoji refined-twitter_emoji">${emoji}</span>`;
 
-	$('.Emoji--forText').replaceWith(function () {
-		return emojiWrap($(this).attr('alt'));
+	$(`.Emoji--forText:not(.${handledClass})`).after(function () {
+		this.classList.add(handledClass);
+		return emojiWrap(this.alt);
 	});
 
-	$('.Emoji--forLinks').replaceWith(function () {
+	$(`.Emoji--forLinks:not(.${handledClass})`).after(function () {
+		this.classList.add(handledClass);
 		const systemEmojiEl = $(this).next('span.visuallyhidden');
 		const emojiText = systemEmojiEl.text();
-		systemEmojiEl.remove();
 		return emojiWrap(emojiText);
 	});
 }

--- a/source/style/content.css
+++ b/source/style/content.css
@@ -92,6 +92,6 @@ Dashboard
 .refined-twitter_emoji {
 	letter-spacing: 0.5em;
 }
-.Emoji.refined-twitter---handled {
+.Emoji.refined-twitter--handled {
 	display: none;
 }

--- a/source/style/content.css
+++ b/source/style/content.css
@@ -92,3 +92,6 @@ Dashboard
 .refined-twitter_emoji {
 	letter-spacing: 0.5em;
 }
+.Emoji.refined-twitter---handled {
+	display: none;
+}


### PR DESCRIPTION
Fixes #44
Closes #49

Stylish code to undo it:

```css
.Emoji.refined-twitter--handled {
	display: initial;
}

.Emoji.refined-twitter_emoji {
	display: none;
}
```

In my tests this change doesn't seem to revert the bugfixes in #35 