### PR TITLE
Add keyboard shortcut to toggle night mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ We use Twitter a lot and notice many dumb annoyances we'd like to fix. So here b
 - Prevents DM modal from closing when (accidentally) clicking outside the modal.
 - Highlight your mentions in the stream
 - [Adds a `Likes` button to the main navbar](https://user-images.githubusercontent.com/14620121/35988497-ace9f93e-0ce5-11e8-8675-17e6ee38cd99.png)
+- Keyboard shortcut to toggle Night Mode (Ctrl-m).
 
 Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10). And press <kbd>Command/Ctrl</kbd> <kbd>?</kbd> to see all keyboard shortcuts.
 

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,9 @@ We use Twitter a lot and notice many dumb annoyances we'd like to fix. So here b
 - Prevents DM modal from closing when (accidentally) clicking outside the modal.
 - Highlight your mentions in the stream
 - [Adds a `Likes` button to the main navbar](https://user-images.githubusercontent.com/14620121/35988497-ace9f93e-0ce5-11e8-8675-17e6ee38cd99.png)
-- Keyboard shortcut to toggle Night Mode (Ctrl-m).
+- Keyboard shortcut to toggle Night Mode (<kbd>Ctrl</kbd><kbd>m</kbd>).
 
-Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10). And press <kbd>Command/Ctrl</kbd> <kbd>?</kbd> to see all keyboard shortcuts.
+Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10) and you can toggle it using <kbd>Ctrl</kbd><kbd>m</kbd>. And press <kbd>Command/Ctrl</kbd> <kbd>?</kbd> to see all keyboard shortcuts.
 
 <img src="media/screenshot.gif" width="1272">
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ We use Twitter a lot and notice many dumb annoyances we'd like to fix. So here b
 - [Adds a `Likes` button to the main navbar](https://user-images.githubusercontent.com/14620121/35988497-ace9f93e-0ce5-11e8-8675-17e6ee38cd99.png)
 - Keyboard shortcut to toggle Night Mode (<kbd>Ctrl</kbd><kbd>m</kbd>).
 
-Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10) and you can toggle it using <kbd>Ctrl</kbd><kbd>m</kbd>. And press <kbd>Command/Ctrl</kbd> <kbd>?</kbd> to see all keyboard shortcuts.
+Tip: Twitter has a native [dark mode](https://github.com/sindresorhus/refined-twitter/issues/10) and you can toggle it using <kbd>Ctrl</kbd><kbd>m</kbd>. And press <kbd>Shift</kbd> <kbd>?</kbd> to see all keyboard shortcuts.
 
 <img src="media/screenshot.gif" width="1272">
 

--- a/source/content.js
+++ b/source/content.js
@@ -6,6 +6,7 @@ import userChoiceColor from './features/user-choice-color';
 import codeHighlight from './features/code-highlight';
 import mentionHighlight from './features/mentions-highlight';
 import addLikesButtonNavBar from './features/likes-button-navbar';
+import keyboardShortcuts from './features/keyboard-shortcuts';
 
 function cleanNavbarDropdown() {
 	$('#user-dropdown').find('[data-nav="all_moments"], [data-nav="ads"], [data-nav="promote-mode"], [data-nav="help_center"]').parent().hide();
@@ -55,6 +56,7 @@ function onSingleTweetOpen(cb) {
 
 function onDomReady() {
 	safely(cleanNavbarDropdown);
+	safely(keyboardShortcuts);
 
 	onRouteChange(() => {
 		safely(autoLoadNewTweets);

--- a/source/features/keyboard-shortcuts.js
+++ b/source/features/keyboard-shortcuts.js
@@ -1,3 +1,9 @@
+const toggleNightMode = () => {
+	if (document.querySelector('.nightmode-toggle')) {
+		document.querySelector('.nightmode-toggle').click();
+	}
+};
+
 export default async () => {
 	const customShortcuts = [
 		{
@@ -29,22 +35,21 @@ export default async () => {
 		const keyName = event.key;
 		switch (keyName) {
 			case event.ctrlKey && 'm':
-				if (document.querySelector('.nightmode-toggle')) {
-					document.querySelector('.nightmode-toggle').click();
-				}
+				toggleNightMode();
 				break;
 			default:
 				break;
 		}
 	});
 
-	if (document.querySelector('#init-data')) {
-		const initData = JSON.parse(document.querySelector('#init-data').value);
+	const initDataElement = document.querySelector('#init-data');
+	if (initDataElement) {
+		const initData = JSON.parse(initDataElement.value);
 		const updatedShortcuts = initData.keyboardShortcuts;
-		for (let i = 0; i < updatedShortcuts.length; i++) {
-			updatedShortcuts[i].shortcuts = updatedShortcuts[i].shortcuts.concat(customShortcuts[i].shortcuts);
+		for (const [i, item] of updatedShortcuts.entries()) {
+			item.shortcuts = item.shortcuts.concat(customShortcuts[i].shortcuts);
 		}
 		initData.keyboardShortcuts = updatedShortcuts;
-		document.querySelector('#init-data').value = JSON.stringify(initData);
+		initDataElement.value = JSON.stringify(initData);
 	}
 };

--- a/source/features/keyboard-shortcuts.js
+++ b/source/features/keyboard-shortcuts.js
@@ -1,10 +1,11 @@
 const toggleNightMode = () => {
-	if (document.querySelector('.nightmode-toggle')) {
-		document.querySelector('.nightmode-toggle').click();
+	const nightmodeToggle = document.querySelector('.nightmode-toggle');
+	if (nightmodeToggle) {
+		nightmodeToggle.click();
 	}
 };
 
-export default async () => {
+export default () => {
 	const customShortcuts = [
 		{
 			name: 'Actions',

--- a/source/features/keyboard-shortcuts.js
+++ b/source/features/keyboard-shortcuts.js
@@ -45,7 +45,7 @@ export default async () => {
 	const initDataElement = document.querySelector('#init-data');
 	if (initDataElement) {
 		const initData = JSON.parse(initDataElement.value);
-		const updatedShortcuts = initData.keyboardShortcuts;
+		const updatedShortcuts = [...initData.keyboardShortcuts];
 		for (const [i, item] of updatedShortcuts.entries()) {
 			item.shortcuts = item.shortcuts.concat(customShortcuts[i].shortcuts);
 		}

--- a/source/features/keyboard-shortcuts.js
+++ b/source/features/keyboard-shortcuts.js
@@ -1,0 +1,50 @@
+export default async () => {
+	const customShortcuts = [
+		{
+			name: 'Actions',
+			description: 'Shortcuts for common actions.',
+			shortcuts: [
+				{
+					keys: [
+						'Ctrl',
+						'm'
+					],
+					description: 'Toggle Night Mode'
+				}
+			]
+		},
+		{
+			name: 'Navigation',
+			description: 'Shortcuts for navigating between items in timelines.',
+			shortcuts: []
+		},
+		{
+			name: 'Timelines',
+			description: 'Shortcuts for navigating to different timelines or pages.',
+			shortcuts: []
+		}
+	];
+
+	document.addEventListener('keydown', event => {
+		const keyName = event.key;
+		switch (keyName) {
+			case event.ctrlKey && 'm':
+				if (document.querySelector('.nightmode-toggle')) {
+					document.querySelector('.nightmode-toggle').click();
+				}
+				break;
+			default:
+				break;
+		}
+	});
+
+	if (document.querySelector('#init-data')) {
+		const initData = JSON.parse(document.querySelector('#init-data').value);
+		const updatedShortcuts = initData.keyboardShortcuts;
+		for (let i = 0; i < updatedShortcuts.length; i++) {
+			updatedShortcuts[i].shortcuts = updatedShortcuts[i].shortcuts.concat(customShortcuts[i].shortcuts);
+		}
+		initData.keyboardShortcuts = updatedShortcuts;
+		document.querySelector('#init-data').value = JSON.stringify(initData);
+	}
+};


### PR DESCRIPTION
fixes #28 

Added a new 'keyboard shortcuts' feature so that more custom shortcuts could be implemented in the future.
Also adds the custom shortcuts keys and description to the 'Keyboard Shortcuts' help modal.

To toggle night mode I just programmatically clicked the night mode element, this is a bit forceful and ugly, I'm trying to find a better solution now. (still, because the navbar is always there, this seems to work).

Feedback is welcome :smile: 

P.S.: the shortcut used to toggle night mode is Ctrl+m