### PR TITLE
Style text in backticks

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -7,6 +7,7 @@ import codeHighlight from './features/code-highlight';
 import mentionHighlight from './features/mentions-highlight';
 import addLikesButtonNavBar from './features/likes-button-navbar';
 import keyboardShortcuts from './features/keyboard-shortcuts';
+import renderInlineCode from './features/markdown';
 
 function cleanNavbarDropdown() {
 	$('#user-dropdown').find('[data-nav="all_moments"], [data-nav="ads"], [data-nav="promote-mode"], [data-nav="help_center"]').parent().hide();
@@ -68,6 +69,7 @@ function onDomReady() {
 			safely(hideLikeTweets);
 			safely(inlineInstagramPhotos);
 			safely(hidePromotedTweets);
+			safely(renderInlineCode);
 		});
 	});
 
@@ -75,6 +77,7 @@ function onDomReady() {
 		safely(codeHighlight);
 		safely(mentionHighlight);
 		safely(inlineInstagramPhotos);
+		safely(renderInlineCode);
 	});
 }
 

--- a/source/features/markdown.js
+++ b/source/features/markdown.js
@@ -1,0 +1,34 @@
+import {h} from 'dom-chef';
+
+function styleInlineCode(md) {
+	console.log(md);
+	return (
+		<code class="refined_twitter_markdown">
+			{md}
+		</code>
+	);
+}
+
+function splitTextReducer(frag, text, index) {
+	if (index % 2) { // Code is always in odd positions
+		frag.append(styleInlineCode(text));
+	} else if (text.length > 0) {
+		frag.append(text);
+	}
+
+	return frag;
+}
+
+export default function () {
+	const splittingRegex = /`(.*?)`/g;
+	$('.tweet-text').each((i, el) => {
+		const tweetWithBackticks = el.textContent.split(splittingRegex);
+
+		if (tweetWithBackticks.length === 1) {
+			return;
+		}
+
+		const frag = tweetWithBackticks.reduce(splitTextReducer, new DocumentFragment());
+		$(el).html(frag);
+	});
+}

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -33,7 +33,8 @@
 			],
 			"css": [
 				"style/content.css",
-				"style/code-highlight.css"
+				"style/code-highlight.css",
+				"style/markdown.css"
 			],
 			"js": [
 				"jquery.slim.min.js",

--- a/source/style/markdown.css
+++ b/source/style/markdown.css
@@ -1,0 +1,4 @@
+code.refined_twitter_markdown {
+  font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
+  background-color: rgba(27,31,35,0.05);
+}


### PR DESCRIPTION
Adds initial support for styling text in backticks as code. I stole a lot of code from `features/code-highlight.js`.

![image](https://user-images.githubusercontent.com/12901172/37257908-cb46e0fe-2545-11e8-9bf3-097ad81c7e17.png)


Also I'm sort of new at contributing to open source, any suggestions for improving are welcome.