### PR TITLE
Move dropdown menu a bit to the right

### DIFF
--- a/source/style/content.css
+++ b/source/style/content.css
@@ -144,3 +144,12 @@ code.refined-twitter_markdown {
 	margin: 0;
 	font-size: 90%;
 }
+
+/* Move dropdown menu to the right */
+.DashUserDropdown {
+	transform: translateX(145px);
+}
+
+.dropdown-caret {
+	transform: translateX(-145px);
+}


### PR DESCRIPTION
I think it's a little annoying that the dropdown menu appears on top of your feed when there's all that space to the right. This PR shifts it the right a bit, and this is also how it looks without this extension.

**Before**
![image](https://user-images.githubusercontent.com/12901172/38179466-ab3c5336-35f1-11e8-8f86-8f314b8ed56c.png)


**After**
![image](https://user-images.githubusercontent.com/12901172/38179467-adfca4f4-35f1-11e8-8da7-f9b6c6aa8e56.png)

**Extension Off**
![image](https://user-images.githubusercontent.com/12901172/38179545-b618a998-35f2-11e8-97b3-87c6ab613211.png)

