### PR TITLE
Fix position for search bar's caret

### DIFF
--- a/source/style/content.css
+++ b/source/style/content.css
@@ -150,6 +150,6 @@ code.refined-twitter_markdown {
 	transform: translateX(145px);
 }
 
-.dropdown-caret {
+.DashUserDropdown .dropdown-caret {
 	transform: translateX(-145px);
 }


### PR DESCRIPTION
![refined-twitter-dropdown-caret](https://user-images.githubusercontent.com/3594463/38837263-4bda7c2e-419f-11e8-96f7-d7941771c6e4.png)
PR https://github.com/sindresorhus/refined-twitter/pull/92 caused the caret under the search bar to also be shifted to the left (above image). This PR brings it back to its position by specifying the ancestor of the div to translate.