### PR TITLE
Hide "and others follow" from stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ We use Twitter a lot and notice many dumb annoyances we'd like to fix. So here b
 - [Embeds the photo from Instagram links directly in the tweet.](https://user-images.githubusercontent.com/170270/34315380-12d52994-e77f-11e7-8e23-27b76aee4df2.png)
 - Improves performance. <sup>[1](https://github.com/sindresorhus/refined-twitter/pull/14)</sup> <sup>[2](https://github.com/sindresorhus/refined-twitter/commit/23897e251d2bc8d59526129ce54c7a5bf1ef884c)</sup>
 - Hides "Liked" tweets in the stream.
+- [Hides "And others follow" tweets in the stream.](https://user-images.githubusercontent.com/5341072/39945031-cc81125a-5560-11e8-8334-ea310a9dfdad.png)
 - [Syntax highlighting in code blocks.](https://github.com/sindresorhus/refined-twitter/issues/37)
 - [Adds Markdown-like styling of `text wrapped in backticks`.](https://user-images.githubusercontent.com/12901172/38168571-d9bd82ea-351d-11e8-9858-0d7c8993cdd3.png)
 - Uses the original image in tweet image galleries instead of a downsized version.

--- a/source/content.js
+++ b/source/content.js
@@ -15,6 +15,10 @@ function cleanNavbarDropdown() {
 	$('#user-dropdown').find('[data-nav="all_moments"], [data-nav="ads"], [data-nav="promote-mode"], [data-nav="help_center"]').parent().hide();
 }
 
+function hideFollowTweets() {
+	$('[data-component-context="suggest_pyle_tweet"]').parents('.js-stream-item').hide();
+}
+
 function hideLikeTweets() {
 	$('.tweet-context .Icon--heartBadge').parents('.js-stream-item').hide();
 }
@@ -90,6 +94,7 @@ function onDomReady() {
 		onNewTweets(() => {
 			safely(codeHighlight);
 			safely(mentionHighlight);
+			safely(hideFollowTweets);
 			safely(hideLikeTweets);
 			safely(inlineInstagramPhotos);
 			safely(hidePromotedTweets);


### PR DESCRIPTION
This is really hard to test because I cannot get a tweet like that to show up. It's based on Issue #112  using the idea that these tweets are marked with `data-component-context="suggest_pyle_tweet"`.

Fixes #112