### PR TITLE
Fix error `val.split is not a function`

### DIFF
--- a/source/features/inline-code.js
+++ b/source/features/inline-code.js
@@ -5,7 +5,7 @@ function styleInlineCode(md) {
 }
 
 function isElement(el) {
-	return el instanceof HTMLElement;
+	return el instanceof HTMLElement || el instanceof Text;
 }
 
 function splitTextReducer(frag, text, index) {


### PR DESCRIPTION
This Extention blow my mind!!

# Sammary
Following Error was occurring on my timeline.

<img width="1434" alt="screen shot 2018-08-16 at 8 06 41" src="https://user-images.githubusercontent.com/5501268/44179960-d5ac2480-a134-11e8-91c5-bbdc03b9daf2.png">

# Investigation
`console.log()` target value.

<img width="465" alt="screen shot 2018-08-16 at 9 04 41" src="https://user-images.githubusercontent.com/5501268/44180139-cc6f8780-a135-11e8-94b8-f9e59c42cfc6.png">

## dump

<img width="1440" alt="screen shot 2018-08-16 at 9 03 54" src="https://user-images.githubusercontent.com/5501268/44180060-54a15d00-a135-11e8-839a-c03338e1bc7f.png">


# Cause

The cause was passing [Text](https://developer.mozilla.org/en-US/docs/Web/API/Text) to String.prototype.split().

# FIx
I added [Text](https://developer.mozilla.org/en-US/docs/Web/API/Text) in the early return condition that inner `isElement()`.

But I don't is this way ideally?

Thanks your review😀 