### PR TITLE
Add feature toggle for `Hide "Liked a reply to you" notification activity`

### DIFF
--- a/source/features/index.js
+++ b/source/features/index.js
@@ -99,6 +99,12 @@ export const features = {
 		label: 'Hide "Added you to a list" activity',
 		runOnInit: true
 	},
+	hideNotificationsLikedReplyActivity: {
+		id: 'feature-notifications-hide-liked-reply-activity',
+		category: 'notifications',
+		label: 'Hide "Liked a reply to you" activity',
+		runOnInit: true
+	},
 
 	/* PROFILE */
 	hideProfileHeader: {

--- a/source/style/content.css
+++ b/source/style/content.css
@@ -217,6 +217,6 @@ code.refined-twitter_markdown {
 }
 
 /* Hide `Liked a reply to you` notifications */
-.stream-item-favorited_mention {
+.feature-notifications-hide-liked-reply-activity .stream-item-favorited_mention {
 	display: none;
 }


### PR DESCRIPTION
This option was missing from #131 :) 

<!--
![image](https://user-images.githubusercontent.com/619186/44380063-8b81c500-a4df-11e8-99d3-ffe2582dfe0a.png)
-->