### PR TITLE
Add opt-in option to hide retweets

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -74,6 +74,7 @@ function onDomReady() {
 			enableFeature(features.mentionHighlight);
 			enableFeature(features.hideFollowTweets);
 			enableFeature(features.hideLikeTweets);
+			enableFeature(features.hideRetweets);
 			enableFeature(features.inlineInstagramPhotos);
 			enableFeature(features.hidePromotedTweets);
 			enableFeature(features.renderInlineCode);

--- a/source/features/hide-retweets.js
+++ b/source/features/hide-retweets.js
@@ -1,0 +1,3 @@
+export default function () {
+	$('.tweet-context .Icon--retweeted').parents('.js-stream-item').hide();
+}

--- a/source/features/index.js
+++ b/source/features/index.js
@@ -148,7 +148,7 @@ export const features = {
 	hideRetweets: {
 		id: 'feature-hide-retweets',
 		category: 'timeline',
-		label: 'Hide Retweets in the stream',
+		label: 'Hide retweets in the stream',
 		enabledByDefault: false,
 		fn: require('./hide-retweets').default
 	},

--- a/source/features/index.js
+++ b/source/features/index.js
@@ -145,6 +145,13 @@ export const features = {
 		label: 'Hide "Liked" tweets in the stream',
 		fn: require('./hide-like-tweets').default
 	},
+	hideRetweets: {
+		id: 'feature-hide-retweets',
+		category: 'timeline',
+		label: 'Hide Retweets in the stream',
+		enabledByDefault: false,
+		fn: require('./hide-retweets').default
+	},
 	hidePromotedTweets: {
 		id: 'feature-hide-promoted-tweets',
 		category: 'timeline',


### PR DESCRIPTION
I defaulted this to off since retweets are a little less noisy than likes.