### PR TITLE
Suggest Stylus instead of Stylish in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ We're happy to receive suggestions and contributions, but be aware this is an op
 
 This doesn't necessarily limit you from manually disabling functionality that is not useful for you. Options include:
 
-1. *(CSS Only)* Use a Chrome extension that allows injecting custom styles into sites, based on a URL pattern. [Stylish](https://chrome.google.com/webstore/detail/stylish/fjnbnpbmkenffdnngjfgmeleoegfcffe?hl=en) is one such tool. [Example](https://github.com/sindresorhus/refined-github/issues/136#issuecomment-204072018)
+1. *(CSS Only)* Use a Chrome extension that allows injecting custom styles into sites, based on a URL pattern. [Stylus](https://add0n.com/stylus.html) is one such tool. [Example](https://github.com/sindresorhus/refined-github/issues/136#issuecomment-204072018)
 
 2. Clone the repository, make the adjustments you need, and [load the unpacked extension in Chrome](https://developer.chrome.com/extensions/getstarted#unpacked), rather than installing from the Chrome Store.
 


### PR DESCRIPTION
As discovered this year by Robert Heaton, ["Stylish" browser extension steals all your internet history](https://robertheaton.com/2018/07/02/stylish-browser-extension-steals-your-internet-history/).

Our current README recommends the usage of that extension, so this pull requests changes it to suggest **Stylus**, a Stylish fork with no analytics, instead.