### PR TITLE
Don't autoload tweets when a modal is open

### DIFF
--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -80,7 +80,7 @@ export const getUsername = () => document.querySelector('.DashUserDropdown-userI
 
 export const isModalOpen = () => {
 	const hasPermalinkOverlay = $('#permalink-overlay').is(':visible');
-	const isDMModalOpen = $('#dm_dialog').is(':visible');
+	const isDMModalOpen = $('.modal').is(':visible');
 	return hasPermalinkOverlay || isDMModalOpen;
 };
 


### PR DESCRIPTION
If you're on your timeline and click on reply to a tweet, because it's not on `#dm_dialog` it still clicks the button, which then closes things like adding gifs or whatever.

All modals in my tests have a `.modal` class on it, so this changes from `#dm_dialog` to `.modal` so that it doesn't autoload when doing anything in a modal.