### PR TITLE
Drop language bar from code blocks

### DIFF
--- a/source/features/code-highlight.js
+++ b/source/features/code-highlight.js
@@ -38,13 +38,13 @@ function highlightCode(md) {
 		return (
 			<pre class="refined-twitter_highlight language-txt">
 				<code class="language-txt">
-					{code}
+					{code.trim()}
 				</code>
 			</pre>
 		);
 	}
 
-	const highlightedCode = prism.highlight(code, prism.languages[selectedLang]);
+	const highlightedCode = prism.highlight(code.trim(), prism.languages[selectedLang]);
 
 	return (
 		<div class="refined-twitter_highlight">

--- a/source/features/code-highlight.js
+++ b/source/features/code-highlight.js
@@ -48,9 +48,6 @@ function highlightCode(md) {
 
 	return (
 		<div class="refined-twitter_highlight">
-			<div class="refined-twitter_highlight-lang">
-				{selectedLang}
-			</div>
 			<pre class={`language-${selectedLang}`}>
 				<code class={`language-${selectedLang}`}>
 					{domify(highlightedCode)}

--- a/source/style/code-highlight.css
+++ b/source/style/code-highlight.css
@@ -31,7 +31,7 @@ pre[class*="language-"] {
 
 /* Code blocks */
 pre[class*="language-"] {
-	padding: 2.1em 1em 1em;
+	padding: 1em;
 	overflow: auto;
 	border-radius: 0.3em;
 	line-height: 0;
@@ -153,21 +153,4 @@ pre[class*="language-"] {
 	border-radius: 0.3em;
 	overflow: hidden;
 	font-size: 14px;
-}
-
-.refined-twitter_highlight-lang {
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 100%;
-	height: 30px;
-	line-height: 30px;
-	font-size: 10px;
-	white-space: initial;
-	padding-right: 10px;
-	box-sizing: border-box;
-	text-align: right;
-	color: #ffffff6e;
-	background: #ffffff12;
-	z-index: 1;
 }


### PR DESCRIPTION
Test on: https://twitter.com/sindresorhus/status/953739369130708994

<img width="589" alt="screenshot 2019-02-27 at 01 19 56" src="https://user-images.githubusercontent.com/1402241/53433258-0dbee900-3a2f-11e9-87be-7fe1cfbb02e5.png">

1. I don't think it's particularly useful.
2. GitHub/StackOverflow don't show that for inlined code either.
3. It's unsightly.

Please test before merging.