### PR TITLE
Fix Instagram post query selector

### DIFF
--- a/source/features/inline-instagram-photos.js
+++ b/source/features/inline-instagram-photos.js
@@ -29,7 +29,7 @@ async function getInstagramPhotoUrl(instagramPostUrl) {
 }
 
 export default function () {
-	$('.twitter-timeline-link[data-expanded-url*="//www.instagram.com').each(async (idx, instagramAnchor) => {
+	$('.twitter-timeline-link[data-expanded-url*="//www.instagram.com/p/"]').each(async (idx, instagramAnchor) => {
 		const tweetElement = $(instagramAnchor).parents('.js-tweet-text-container');
 		const instagramPostUrl = instagramAnchor.dataset.expandedUrl;
 		const shouldInlinePhoto = tweetElement.siblings('.AdaptiveMediaOuterContainer').length < 1;


### PR DESCRIPTION
Fixes #177 

Updated the query selector to get only `instagram.com/p/` posts.