### PR TITLE
Fix image-alternatives feature

### DIFF
--- a/source/features/image-alternatives.js
+++ b/source/features/image-alternatives.js
@@ -22,6 +22,9 @@ export default function () {
 			// Current image equals the avatar on the current page
 			if (imgAvatar && img.src === imgAvatar.src) {
 				imgContainer.classList.add('refined-twitter_image-alt_profile-container');
+			} else {
+				// Remove previouly added classname if container is not for the profile avatar
+				imgContainer.classList.remove('refined-twitter_image-alt_profile-container');
 			}
 
 			if (imgContainer.classList.contains('AdaptiveMedia-photoContainer')) {


### PR DESCRIPTION
Problem:
If user clicks on avatar first (which is round shaped), then on some picture with alt text in profile gallery, previously added class doesn't get removed, image stays with round borders. Also alternative text gets displayed on the bottom, not on top as planned.

Better shown on gif:
![Peek 2019-04-13 15-18](https://user-images.githubusercontent.com/4655259/56079599-9cc96a00-5dff-11e9-99d5-4d30a3d588d4.gif)

I fixed that by removing `refined-twitter_image-alt_profile-container` classname from container