### PR TITLE
Fix: Search function gone with 'What's Happening' and 'Who To Follow' boxes #197

### DIFF
--- a/source/features/hide-trends-and-who-to-follow.js
+++ b/source/features/hide-trends-and-who-to-follow.js
@@ -1,7 +1,7 @@
 import elementReady from 'element-ready';
 
 export default async function () {
-	const trending = await elementReady('[aria-label="Timeline: Trending now"]');
+	const trending = await elementReady('[class="css-1dbjc4n r-1adg3ll r-1ny4l3l"]');
 	$(trending).hide();
 	const whoToFollow = await elementReady('[class="css-1dbjc4n r-1u4rsef r-9cbz99 r-1867qdf r-1phboty r-rs99b7 r-ku1wi2 r-1bro5k0 r-1udh08x"]');
 	$(whoToFollow).hide();

--- a/source/features/hide-trends-and-who-to-follow.js
+++ b/source/features/hide-trends-and-who-to-follow.js
@@ -1,6 +1,8 @@
 import elementReady from 'element-ready';
 
 export default async function () {
-	const sidebar = await elementReady('[data-testid=sidebarColumn]');
-	$(sidebar).hide();
+	const trending = await elementReady('[aria-label="Timeline: Trending now"]');
+	$(trending).hide();
+	const whoToFollow = await elementReady('[class="css-1dbjc4n r-1u4rsef r-9cbz99 r-1867qdf r-1phboty r-rs99b7 r-ku1wi2 r-1bro5k0 r-1udh08x"]');
+	$(whoToFollow).hide();
 }

--- a/source/features/hide-trends-and-who-to-follow.js
+++ b/source/features/hide-trends-and-who-to-follow.js
@@ -1,7 +1,7 @@
 import elementReady from 'element-ready';
 
 export default async function () {
-	const trending = await elementReady('[class="css-1dbjc4n r-1adg3ll r-1ny4l3l"]');
+	const trending = await elementReady('[aria-labelledby="accessible-list-0"]');
 	$(trending).hide();
 	const whoToFollow = await elementReady('[class="css-1dbjc4n r-1u4rsef r-9cbz99 r-1867qdf r-1phboty r-rs99b7 r-ku1wi2 r-1bro5k0 r-1udh08x"]');
 	$(whoToFollow).hide();


### PR DESCRIPTION
Hi, the new "hide 'what's happening' and 'Who to follow' option will take the search away with them. This PR should fix the issue. 

Please let me know if there is any problem. Thank you!
